### PR TITLE
fix: DLQ messages only fetched once on reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,19 +2,24 @@ import { BrowserRouter as Router } from "react-router-dom";
 import Header from "./components/Header";
 import CategorySidebar from "./components/CategorySidebar";
 import SelectedWindow from "./components/SelectedWindow";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { deadLog } from "./types";
 import { fetchDlq } from "./utils";
 
 function App() {
   const [deadLogs, setDeadLogs] = useState<deadLog[]>([]);
-  const [loadingDLQ, setLoadingDLQ] = useState(true);
+  const [loadingDLQ, setLoadingDLQ] = useState(false);
+  const fetchInProgressRef = useRef(false);
 
   useEffect(() => {
-    (async () => {
-      await fetchDlq(setDeadLogs);
-      setLoadingDLQ(false);
-    })();
+    if (!fetchInProgressRef.current) {
+      fetchInProgressRef.current = true;
+      (async () => {
+        setLoadingDLQ(true);
+        await fetchDlq(setDeadLogs);
+        setLoadingDLQ(false);
+      })();
+    }
   }, []);
 
   return (
@@ -29,6 +34,7 @@ function App() {
           setDeadLogs={setDeadLogs}
           loadingDLQ={loadingDLQ}
           setLoadingDLQ={setLoadingDLQ}
+          fetchInProgressRef={fetchInProgressRef}
         />
       </main>
     </Router>

--- a/src/components/DlqTable.tsx
+++ b/src/components/DlqTable.tsx
@@ -19,6 +19,7 @@ interface DlqTableProps {
   setDeadLogs: React.Dispatch<React.SetStateAction<deadLog[]>>;
   loadingDLQ: boolean;
   setLoadingDLQ: React.Dispatch<React.SetStateAction<boolean>>;
+  fetchInProgressRef: React.MutableRefObject<boolean>;
 }
 
 function DlqTable({
@@ -26,6 +27,7 @@ function DlqTable({
   setDeadLogs,
   loadingDLQ,
   setLoadingDLQ,
+  fetchInProgressRef,
 }: DlqTableProps) {
   const navigate = useNavigate();
 
@@ -37,8 +39,9 @@ function DlqTable({
     useState<FilterState>("on");
 
   useEffect(() => {
-    setLoadingDLQ(true);
+    fetchInProgressRef.current = true;
     (async () => {
+      setLoadingDLQ(true);
       await fetchDlq(setDeadLogs);
       setLoadingDLQ(false);
     })();
@@ -46,7 +49,6 @@ function DlqTable({
 
   useEffect(() => {
     if (loadingDLQ) return;
-
     const newFilteredLogs = deadLogs.filter((log) => {
       const matchesUserId = log.user_id
         .toLowerCase()

--- a/src/components/SelectedWindow.tsx
+++ b/src/components/SelectedWindow.tsx
@@ -10,6 +10,7 @@ interface SelectedWindowProps {
   setDeadLogs: React.Dispatch<React.SetStateAction<deadLog[]>>;
   loadingDLQ: boolean;
   setLoadingDLQ: React.Dispatch<React.SetStateAction<boolean>>;
+  fetchInProgressRef: React.MutableRefObject<boolean>;
 }
 
 function SelectedWindow({
@@ -17,6 +18,7 @@ function SelectedWindow({
   setDeadLogs,
   loadingDLQ,
   setLoadingDLQ,
+  fetchInProgressRef,
 }: SelectedWindowProps) {
   const location = useLocation();
 
@@ -31,6 +33,7 @@ function SelectedWindow({
           setDeadLogs={setDeadLogs}
           loadingDLQ={loadingDLQ}
           setLoadingDLQ={setLoadingDLQ}
+          fetchInProgressRef={fetchInProgressRef}
         />
       )}
     </>


### PR DESCRIPTION
When the user is on the DLQ page of the dashboard and reloads the app, the DLQ messages were being fetched twice. This was causing an issue where the user would see a flash of messages that would then disappear. This fixes the double-loading bug.

The messages in the queue on AWS are still subject to visibility timeout. Frequent reloading/refetching will cause messages that are still in the visibility timeout window to not get fetched on the next load.